### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ when using `djangocms-text-ckeditor`_ use ``CKEDITOR_SETTINGS`` instead of
 ``CKEDITOR_CONFIGS``.
 
 
-.. _Canonical URLs: http://django-filer.readthedocs.org/en/latest/installation.html#canonical-urls
+.. _Canonical URLs: https://django-filer.readthedocs.io/en/latest/installation.html#canonical-urls
 .. _django CMS: https://pypi.python.org/pypi/django-cms
 .. _django-filer: https://pypi.python.org/pypi/django-filer
 .. _cmsplugin_filer_image: https://pypi.python.org/pypi/cmsplugin_filer_image


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.