### PR TITLE
Removed 'static' directory from base_path variable in filer image dialog

### DIFF
--- a/ckeditor_filebrowser_filer/static/ckeditor/ckeditor/plugins/filerimage/dialogs/filerImageDialog.js
+++ b/ckeditor_filebrowser_filer/static/ckeditor/ckeditor/plugins/filerimage/dialogs/filerImageDialog.js
@@ -18,7 +18,7 @@
 			lang = editor.lang.filerimage,
 			commonLang = editor.lang.common,
 			base_ckeditor = '/filebrowser_filer',
-			base_static = editor.plugins.filerimage.path + '../../../../../static',
+			base_static = editor.plugins.filerimage.path + '../../../../../',
 			base_admin = editor.base_admin,
 			nofile_icon = base_static + '/filer/icons/nofile_48x48.png';
 		if (editor.filer_version < 1.2)


### PR DESCRIPTION
Using 

`'/../../../../../static'` causes the URLs to be `static/static/filer/icons/nofile_48x48.png/`.