### PR TITLE
fix urls for Django 1.10 (backwards compatible)

### DIFF
--- a/ckeditor_filebrowser_filer/urls.py
+++ b/ckeditor_filebrowser_filer/urls.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+try:
+    from django.conf.urls import patterns
+except:
+    def patterns(prefix, *urls):
+        return urls
+
 from .views import *
 
 urlpatterns = patterns('',
@@ -13,4 +19,4 @@ urlpatterns = patterns('',
     url(r'serve/(?P<image_id>\d+)/(?P<thumb_options>\d+)/$', serve_image, name='serve_image'),
     url(r'serve/(?P<image_id>\d+)/(?P<width>\d+)/(?P<height>\d+)/$', serve_image, name='serve_image'),
     url(r'thumbnail_options/$', thumbnail_options, name='thumbnail_options'),
-) 
+)


### PR DESCRIPTION
This PR fixes #24 in a backwards compatible way.

Best regards!