### PR TITLE
fix problem to change (modify src) an existing image

### DIFF
--- a/ckeditor_filebrowser_filer/static/ckeditor/ckeditor/plugins/filerimage/dialogs/filerImageDialog.js
+++ b/ckeditor_filebrowser_filer/static/ckeditor/ckeditor/plugins/filerimage/dialogs/filerImageDialog.js
@@ -55,6 +55,7 @@
 				},
 				// Called by the main commitContent call on dialog confirmation.
 				commit: function (element) {
+					element.$.dataset["ckeSavedSrc"] = this.getValue();
 					element.setAttribute('src', this.getValue());
 				}
 			},


### PR DESCRIPTION
#35 this problem was fixed with PR :)

It was necessary change dataset to change image works, because ckeditor somehow use this property to reference the **src** of the IMG.